### PR TITLE
config: Add an alternative database dialect

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ googletrans==4.0.0rc1
 gtts
 heroku3
 humanize
-image_to_ascii
+image_to_Ascii
 lyricsgenius
 pillow
 psycopg2-binary

--- a/sample_config.env
+++ b/sample_config.env
@@ -11,6 +11,7 @@ SESSION=''
 # Leave default if you deploy on local machine otherwise enter the url by following format.
 # Example: 'postgresql://username:passwd@localhost:5432/db_name'
 DATABASE_URL='postgresql://sedenuserbot:TeamDerUntergang@localhost:5432/userbotdb'
+DATABASE_URL_ALTERNATIVE='sqlite:///userbotdb'
 
 # Chat ID for Log Group
 LOG_ID=''

--- a/sedenbot/__init__.py
+++ b/sedenbot/__init__.py
@@ -8,6 +8,8 @@
 #
 
 
+import socket
+from contextlib import closing
 from importlib import import_module
 from logging import CRITICAL, DEBUG, INFO, basicConfig, getLogger
 from os import environ, listdir, path, remove
@@ -162,6 +164,12 @@ PACKNICK = environ.get('PACKNICK', None)
 DATABASE_URL = environ.get('DATABASE_URL', None)
 if DATABASE_URL and DATABASE_URL.startswith('postgres://'):
     DATABASE_URL = DATABASE_URL.replace('postgres://', 'postgresql://', 1)
+
+# If PostgreSQL socket is not available (which is cause issues) use SQLite dialect
+host, port = DATABASE_URL.split('@')[-1].split('/')[0].split(':')
+with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+    if sock.connect_ex((host, int(port))) != 0:
+        DATABASE_URL = environ.get('DATABASE_URL_ALTERNATIVE', None)
 
 # SedenBot Session
 SESSION = environ.get('SESSION', 'sedenify')


### PR DESCRIPTION
  * If PostgreSQL socket is not available (such as port is not open, firewall etc.) some modules (which are need db to work properly) fails (chat.snips, chat.blacklist etc.).
  - Error(s): 1- connection to server at "localhost" (127.0.0.1), port 5432 failed: Connection refused (0x0000274D/10061) Is the server running on that host and accepting TCP/IP connections? 2- WARNING - Unable to run mutechat, unmutechat commands, no SQL connections found

  * That's why stituations like this serverless SQLite should be used.

Reference: https://stackoverflow.com/a/35370008